### PR TITLE
[Feat] 新增 `Tensor.randn()` 以及 新增 `Tensor.device` 参数

### DIFF
--- a/include/axono/compute/cpu/operators/randn.h
+++ b/include/axono/compute/cpu/operators/randn.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "axono/core/types.h"
+#include "axono/core/tensor.h"
+
+namespace axono::compute::cpu::operators {
+
+core::Status Randn(const core::Context& ctx,
+                   core::Tensor& out,
+                   float mean = 0.0f,
+                   float stddev = 1.0f);
+
+} // namespace axono::compute::cpu::operators

--- a/include/axono/compute/cuda/operators/randn.h
+++ b/include/axono/compute/cuda/operators/randn.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "axono/core/types.h"
+#include "axono/core/tensor.h"
+
+namespace axono::compute::cuda::operators {
+
+core::Status Randn(const core::Context& ctx,
+                   core::Tensor& out,
+                   float mean = 0.0f,
+                   float stddev = 1.0f);
+
+} // namespace axono::compute::cuda::operators

--- a/include/axono/core/tensor.h
+++ b/include/axono/core/tensor.h
@@ -79,6 +79,15 @@ class Tensor {
   Status FillZero();
   Status Fill(void *value, size_t value_size);
 
+  // 正太分布
+  static Tensor randn(
+      const std::vector<size_t>& shape,
+      DataType dtype = DataType::FLOAT32,
+      const std::string& device = "cpu",
+      float mean = 0.0f,
+      float stddev = 1.0f
+  );
+
   // 工具函数
   bool IsSameShape(const Tensor &other) const;
   std::string ToString() const;

--- a/include/axono/pybind/core/tensor.h
+++ b/include/axono/pybind/core/tensor.h
@@ -1,7 +1,6 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-
 #include "axono/core/tensor.h"
 #ifdef COMPILED_WITH_CUDA
 #include "axono/core/cuda/tensor/kernel.h"
@@ -268,6 +267,14 @@ void init_tensor(py::module &m) {
                 py::capsule(self.data<void *>(), [](void *) {}));
           },
           "Get data as bool numpy array")
+      .def_static("randn", 
+                    &axono::core::Tensor::randn,
+                    py::arg("shape"),
+                    py::arg("dtype") = axono::core::DataType::FLOAT32,
+                    py::arg("device") = "cpu",
+                    py::arg("mean") = 0.0f,
+                    py::arg("stddev") = 1.0f,
+                    "Create a tensor with values from normal distribution")
       .def("__copy__",
            [](const axono::core::Tensor &self) {
              return axono::core::Tensor(self.dtype(), self.shape(),

--- a/python/axono/core/tensor.py
+++ b/python/axono/core/tensor.py
@@ -231,6 +231,11 @@ class Tensor:
     @property
     def dtype(self) -> DataType:
         return self._tensor.dtype
+    
+    @property
+    def device(self) -> str:
+        """Return the device on which the tensor resides."""
+        return self._tensor.device
 
     @property
     def shape(self) -> list[int]:
@@ -253,6 +258,18 @@ class Tensor:
 
     def __str__(self) -> str:
         return self._tensor.__str__()
+    
+    @staticmethod
+    def randn(
+        shape: list[int],
+        dtype: DataType = DataType.FLOAT32,
+        device: str = "cpu",
+        mean: float = 0.0,
+        stddev: float = 1.0
+    ) -> "Tensor":
+        """Create a tensor filled with random values sampled from a normal distribution"""
+        tensor = _Tensor.randn(shape, dtype=dtype, device=device, mean=mean, stddev=stddev)
+        return Tensor.from_raw(tensor)
 
     @staticmethod
     def zeros(

--- a/python/tests/core/operators/test_randn.py
+++ b/python/tests/core/operators/test_randn.py
@@ -1,0 +1,103 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from axono.core import DataType, Tensor
+
+device = os.getenv("axono_default_device", "cpu")
+
+
+class TestTensorRandn(unittest.TestCase):
+    """测试 Tensor.randn 正态分布随机数生成"""
+
+    def test_randn_basic_shape_dtype(self):
+        """测试基本形状和数据类型生成"""
+        # 测试不同形状
+        shapes = [[3], [2, 4], [1, 5, 3]]
+        dtypes = [DataType.FLOAT32, DataType.FLOAT64]
+
+        for shape in shapes:
+            for dtype in dtypes:
+                tensor = Tensor.randn(shape=shape, dtype=dtype, device=device)
+                self.assertEqual(tensor.shape, shape, 
+                                f"形状不匹配: 预期 {shape}, 实际 {tensor.shape}")
+                self.assertEqual(tensor.dtype, dtype,
+                                f"数据类型不匹配: 预期 {dtype}, 实际 {tensor.dtype}")
+                self.assertEqual(tensor.device, device,
+                                f"设备不匹配: 预期 {device}, 实际 {tensor.device}")
+                self.assertEqual(tensor.num_elements, np.prod(shape),
+                                f"元素数量错误: 预期 {np.prod(shape)}, 实际 {tensor.num_elements}")
+
+    def test_randn_distribution_properties(self):
+        """测试正态分布的统计特性（均值和标准差）"""
+        shape = [10000, 10000]
+        mean = 2.5
+        stddev = 1.3
+
+        tensor = Tensor.randn(shape=shape, mean=mean, stddev=stddev, device=device)
+        data = tensor.to_numpy()
+
+        # 计算实际均值和标准差（允许一定误差范围）
+        actual_mean = np.mean(data)
+        actual_std = np.std(data)
+
+        # 均值误差允许在 0.05 以内，标准差误差允许在 0.05 以内
+        self.assertAlmostEqual(actual_mean, mean, delta=0.05,
+                              msg=f"均值不符合预期: 预期 {mean}, 实际 {actual_mean}")
+        self.assertAlmostEqual(actual_std, stddev, delta=0.05,
+                              msg=f"标准差不符合预期: 预期 {stddev}, 实际 {actual_std}")
+
+    def test_randn_device_compatibility(self):
+        """测试不同设备（CPU/CUDA）上的生成功能"""
+        cpu_tensor = Tensor.randn(shape=[3, 3], device="cpu")
+        self.assertEqual(cpu_tensor.device, "cpu")
+        cpu_data = cpu_tensor.to_numpy()  # 验证CPU数据可访问
+
+        if "cuda" in device:
+            cuda_tensor = Tensor.randn(shape=[5, 5], device=device)
+            self.assertTrue(cuda_tensor.is_cuda())
+            cuda_data = cuda_tensor.to_numpy()  # 验证CUDA数据可拷贝到CPU
+            self.assertEqual(cuda_data.shape, (5, 5))
+
+    def test_randn_randomness(self):
+        """测试每次调用生成不同的随机数"""
+        tensor1 = Tensor.randn(shape=[100, 100], device=device)
+        tensor2 = Tensor.randn(shape=[100, 100], device=device)
+
+        data1 = tensor1.to_numpy()
+        data2 = tensor2.to_numpy()
+
+        self.assertFalse(np.array_equal(data1, data2), "两次生成的随机数完全相同")
+
+    def test_randn_edge_cases(self):
+        """测试边界情况（空张量、单元素）"""
+        # 空张量
+        empty_tensor = Tensor.randn(shape=[], device=device)
+        self.assertEqual(empty_tensor.num_elements, 0)
+
+        # 单元素张量
+        single_tensor = Tensor.randn(shape=[1], mean=0, stddev=1, device=device)
+        single_data = single_tensor.to_numpy()
+        self.assertEqual(single_data.shape, (1,))
+
+        # 大形状张量（内存分配验证）
+        large_tensor = Tensor.randn(shape=[1024, 1024, 16], device=device)
+        self.assertEqual(large_tensor.num_elements, 1024 * 1024 * 16)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/compute/cpu/operators/randn.cpp
+++ b/src/compute/cpu/operators/randn.cpp
@@ -1,0 +1,46 @@
+#include "axono/compute/cpu/operators/randn.h"
+#include "axono/core/macros.h"
+#include "axono/core/tensor.h"
+#include <random>
+#include <vector>
+
+namespace axono::compute::cpu::operators {
+
+namespace {
+// 线程局部随机数生成器，避免多线程竞争
+thread_local std::mt19937 rng(std::random_device{}());
+
+template <typename T>
+void generate_normal(T* data, size_t num_elements, T mean, T stddev) {
+    std::normal_distribution<T> dist(mean, stddev);
+    for (size_t i = 0; i < num_elements; ++i) {
+        data[i] = dist(rng);
+    }
+}
+} // namespace
+
+core::Status Randn(const core::Context& ctx, 
+                   core::Tensor& out, 
+                   float mean, 
+                   float stddev) {
+    (void)ctx; // 未使用的上下文
+    
+    const size_t num_elements = out.num_elements();
+    if (num_elements == 0) return core::Status::OK;
+
+    switch (out.dtype()) {
+        case core::DataType::FLOAT32:
+            generate_normal(out.data<float>(), num_elements, 
+                           static_cast<float>(mean), static_cast<float>(stddev));
+            break;
+        case core::DataType::FLOAT64:
+            generate_normal(out.data<double>(), num_elements, 
+                           static_cast<double>(mean), static_cast<double>(stddev));
+            break;
+        default:
+            return core::Status::UNSUPPORTED_TYPE;
+    }
+    return core::Status::OK;
+}
+
+} // namespace axono::compute::cpu::operators

--- a/src/compute/cuda/operators/randn.cu
+++ b/src/compute/cuda/operators/randn.cu
@@ -1,0 +1,73 @@
+#include "axono/compute/cuda/operators/randn.h"
+#include "axono/core/cuda/tensor/kernel.h"
+#include "axono/core/types.h"
+#include <curand_kernel.h>
+#include <random>
+
+namespace axono {
+namespace compute {
+namespace cuda {
+namespace operators {
+
+// CUDA 核函数：生成正态分布随机数
+template <typename T>
+__global__ void RandnKernel(T* data, size_t num_elements, float mean, float stddev, unsigned int seed) {
+    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= num_elements) return;
+
+    curandState state;
+    curand_init(seed, idx, 0, &state);
+
+    // 生成标准正态分布（均值0，标准差1），再转换为目标分布
+    float val = curand_normal(&state);
+    data[idx] = static_cast<T>(mean + val * stddev);
+}
+
+// 分派函数：根据数据类型调用对应核函数
+template <typename T>
+core::Status DispatchRandn(const core::Context& ctx, core::Tensor& out, float mean, float stddev) {
+    size_t num_elements = out.num_elements();
+    if (num_elements == 0) return core::Status::OK;
+
+    // 生成随机种子（使用 std::random_device）
+    std::random_device rd;  // 现在可正确识别
+    unsigned int seed = rd();
+
+    // 启动核函数
+    const int block_size = 256;
+    const int grid_size = (num_elements + block_size - 1) / block_size;
+    RandnKernel<T><<<grid_size, block_size>>>(
+        out.data<T>(), num_elements, mean, stddev, seed
+    );
+
+    return core::Status::OK;
+}
+
+// 对外接口实现
+core::Status Randn(const core::Context& ctx, core::Tensor& out, float mean, float stddev) {
+    if (out.is_cuda()) {
+#ifdef COMPILED_WITH_CUDA
+        switch (out.dtype()) {
+            case core::DataType::FLOAT32:
+                return DispatchRandn<float>(ctx, out, mean, stddev);
+            case core::DataType::FLOAT64:
+                return DispatchRandn<double>(ctx, out, mean, stddev);
+            default:
+                return core::Status::UNSUPPORTED_TYPE;
+        }
+#else
+        return core::Status::DEVICE_ERROR;  // 修复：使用正确的枚举值
+#endif
+    } else {
+        return core::Status::DEVICE_ERROR;  // 修复：使用正确的枚举值
+    }
+}
+
+// 显式实例化模板（避免链接错误）
+template core::Status DispatchRandn<float>(const core::Context&, core::Tensor&, float, float);
+template core::Status DispatchRandn<double>(const core::Context&, core::Tensor&, float, float);
+
+}  // namespace operators
+}  // namespace cuda
+}  // namespace compute
+}  // namespace axono


### PR DESCRIPTION
### PR For
Cpp

### PR Types
Feat

### Description
> 测试通过
```python
Python 3.10.10 (main, Mar 21 2023, 18:45:11) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import axono
>>> tensor_cpu = axono.core.Tensor.randn(shape=(2, 3), device="cpu")
>>> print(tensor_cpu)
Tensor(shape=[2, 3], dtype=float32, device=cpu)
>>> print(tensor_cpu.to_numpy())
[[-0.5884073   2.4176564  -1.5667003 ]
 [ 0.5366092  -0.9379911  -0.09735962]]
>>> print(tensor_cpu.to("cuda:0"))
Tensor(shape=[2, 3], dtype=float32, device=cuda:0)
>>> print(tensor_cpu.to_numpy())
[[-0.5884073   2.4176564  -1.5667003 ]
 [ 0.5366092  -0.9379911  -0.09735962]]
>>> tensor_cuda = axono.core.Tensor.randn(shape=(2, 3), device="cuda")
>>> print(tensor_cuda.to_numpy())
[[-0.8028335   0.71464264 -0.52258986]
 [-0.88654155  0.08773689  0.770459  ]]
>>> tensor_cuda = axono.core.Tensor.randn(
...     shape=[4, 5],
...     dtype=DataType.FLOAT32,
...     device="cuda:0",
...     mean=1.0,
...     stddev=0.5
... )
>>> print(tensor_cuda)
Tensor(shape=[4, 5], dtype=float32, device=cuda:0)
```